### PR TITLE
Implement heuristics to compact contiguous text segments

### DIFF
--- a/cmd/transcriber/call/utils.go
+++ b/cmd/transcriber/call/utils.go
@@ -80,13 +80,11 @@ func (t *Transcriber) publishTranscription(tr transcribe.Transcription) (err err
 	}
 	defer textFile.Close()
 
-	if err := tr.WebVTT(vttFile, transcribe.WebVTTOptions{
-		OmitSpeaker: false,
-	}); err != nil {
+	if err := tr.WebVTT(vttFile, t.cfg.OutputOptions.WebVTT); err != nil {
 		return fmt.Errorf("failed to write WebVTT file: %w", err)
 	}
 
-	if err := tr.Text(textFile); err != nil {
+	if err := tr.Text(textFile, t.cfg.OutputOptions.Text); err != nil {
 		return fmt.Errorf("failed to write text file: %w", err)
 	}
 

--- a/cmd/transcriber/main.go
+++ b/cmd/transcriber/main.go
@@ -51,7 +51,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	cfg, err := config.LoadFromEnv()
+	cfg, err := config.FromEnv()
 	if err != nil {
 		slog.Error("failed to load config", slog.String("err", err.Error()))
 		os.Exit(1)

--- a/cmd/transcriber/transcribe/output.go
+++ b/cmd/transcriber/transcribe/output.go
@@ -1,10 +1,6 @@
 package transcribe
 
 import (
-	"fmt"
-	"html"
-	"io"
-	"math"
 	"regexp"
 	"sort"
 	"strings"
@@ -37,25 +33,6 @@ func (ns *namedSegment) sanitize(escapers ...func(string) string) {
 	}
 }
 
-// vttTS converts ts milliseconds in the 00:00:00.000 format.
-func vttTS(ts int64, withMs bool) string {
-	sMs := int64(1000)
-	mMs := 60 * sMs
-	hMs := 60 * mMs
-
-	h := ts / hMs
-	m := (ts - (h * hMs)) / mMs
-
-	if withMs {
-		s := ((ts - (h * hMs)) - m*mMs) / sMs
-		ms := ((ts - (h * hMs)) - m*mMs) - s*sMs
-		return fmt.Sprintf("%02d:%02d:%02d.%03d", h, m, s, ms)
-	}
-
-	s := int64(math.Round(float64(((ts - (h * hMs)) - m*mMs)) / float64(sMs)))
-	return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
-}
-
 func (t Transcription) interleave() []namedSegment {
 	var nss []namedSegment
 
@@ -73,54 +50,4 @@ func (t Transcription) interleave() []namedSegment {
 	})
 
 	return nss
-}
-
-type WebVTTOptions struct {
-	OmitSpeaker bool
-}
-
-func (t Transcription) WebVTT(w io.Writer, opts WebVTTOptions) error {
-	_, err := fmt.Fprintf(w, "WEBVTT\n")
-	if err != nil {
-		return fmt.Errorf("failed to write: %w", err)
-	}
-	for _, s := range t.interleave() {
-		s.sanitize(html.EscapeString)
-
-		_, err = fmt.Fprintf(w, "\n%s --> %s\n", vttTS(s.StartTS, true), vttTS(s.EndTS, true))
-		if err != nil {
-			return fmt.Errorf("failed to write: %w", err)
-		}
-		tmpl := "<v %[1]s>(%[1]s) %[2]s\n"
-		if opts.OmitSpeaker {
-			tmpl = "%[2]s\n"
-		}
-		_, err = fmt.Fprintf(w, tmpl, s.Speaker, s.Text)
-		if err != nil {
-			return fmt.Errorf("failed to write: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func (t Transcription) Text(w io.Writer) error {
-	for i, s := range t.interleave() {
-		s.sanitize()
-
-		nl := "\n"
-		if i == 0 {
-			nl = ""
-		}
-		_, err := fmt.Fprintf(w, "%s%v -> %v\n", nl, vttTS(s.StartTS, false), vttTS(s.EndTS, false))
-		if err != nil {
-			return fmt.Errorf("failed to write: %w", err)
-		}
-		_, err = fmt.Fprintf(w, "%s\n%s\n", s.Speaker, s.Text)
-		if err != nil {
-			return fmt.Errorf("failed to write: %w", err)
-		}
-	}
-
-	return nil
 }

--- a/cmd/transcriber/transcribe/text.go
+++ b/cmd/transcriber/transcribe/text.go
@@ -1,0 +1,143 @@
+package transcribe
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strconv"
+)
+
+type TextCompactOptions struct {
+	SilenceThresholdMs   int
+	MaxSegmentDurationMs int
+}
+
+func (o *TextCompactOptions) SetDefaults() {
+	o.SilenceThresholdMs = 2000
+	o.MaxSegmentDurationMs = 10000
+}
+
+func (o *TextCompactOptions) IsEmpty() bool {
+	return o == nil || *o == TextCompactOptions{}
+}
+
+type TextOptions struct {
+	CompactOptions TextCompactOptions
+}
+
+func (o *TextOptions) SetDefaults() {
+	o.CompactOptions.SetDefaults()
+}
+
+func (o *TextOptions) IsValid() error {
+	if o.CompactOptions.SilenceThresholdMs <= 0 {
+		return fmt.Errorf("SilenceThresholdMs should be a positive number")
+	}
+
+	if o.CompactOptions.MaxSegmentDurationMs <= 0 {
+		return fmt.Errorf("MaxSegmentDurationMs should be a positive number")
+	}
+
+	return nil
+}
+
+func (o *TextOptions) IsEmpty() bool {
+	return o.CompactOptions.IsEmpty()
+}
+
+func (o *TextOptions) ToEnv() []string {
+	return []string{
+		fmt.Sprintf("TEXT_COMPACT_SILENCE_THRESHOLD_MS=%d", o.CompactOptions.SilenceThresholdMs),
+		fmt.Sprintf("TEXT_COMPACT_MAX_SEGMENT_DURATION_MS=%d", o.CompactOptions.MaxSegmentDurationMs),
+	}
+}
+
+func (o *TextOptions) FromEnv() {
+	o.CompactOptions.SilenceThresholdMs, _ = strconv.Atoi(os.Getenv("TEXT_COMPACT_SILENCE_THRESHOLD_MS"))
+	o.CompactOptions.MaxSegmentDurationMs, _ = strconv.Atoi(os.Getenv("TEXT_COMPACT_MAX_SEGMENT_DURATION_MS"))
+}
+
+func (o *TextOptions) ToMap() map[string]any {
+	return map[string]any{
+		"text_compact_silence_threshold_ms":    o.CompactOptions.SilenceThresholdMs,
+		"text_compact_max_segment_duration_ms": o.CompactOptions.MaxSegmentDurationMs,
+	}
+}
+
+func (o *TextOptions) FromMap(m map[string]any) {
+	// These can either be int or float64 dependning whether they have been
+	// previously marshaled or not.
+	switch m["text_compact_silence_threshold_ms"].(type) {
+	case int:
+		o.CompactOptions.SilenceThresholdMs = m["text_compact_silence_threshold_ms"].(int)
+	case float64:
+		o.CompactOptions.SilenceThresholdMs = int(m["text_compact_silence_threshold_ms"].(float64))
+	}
+
+	switch m["text_compact_max_segment_duration_ms"].(type) {
+	case int:
+		o.CompactOptions.MaxSegmentDurationMs = m["text_compact_max_segment_duration_ms"].(int)
+	case float64:
+		o.CompactOptions.MaxSegmentDurationMs = int(m["text_compact_max_segment_duration_ms"].(float64))
+	}
+}
+
+func compactSegments(segments []namedSegment, opts TextCompactOptions) []namedSegment {
+	if len(segments) < 2 {
+		return segments
+	}
+
+	out := []namedSegment{segments[0]}
+
+	for i := 1; i < len(segments); i++ {
+		currSeg := segments[i]
+		prevSeg := segments[i-1]
+
+		// We join the segments if:
+		// - The speaker hasn't changed. This is required to guarantee order (e.g. question/answer sequences).
+		// - There's less than silenceThresholdMs of pause between the end of a previous text segment and the start of the next one.
+		// - The overall (running) duration of the joined segments is less than maxDurationMs seconds.
+		if currSeg.Speaker == prevSeg.Speaker &&
+			int(currSeg.StartTS-prevSeg.EndTS) < opts.SilenceThresholdMs &&
+			int(currSeg.StartTS-out[len(out)-1].StartTS) < opts.MaxSegmentDurationMs {
+
+			slog.Debug(fmt.Sprintf("%d and %d can be joined", i-1, i))
+			out[len(out)-1].Text += " " + currSeg.Text
+			out[len(out)-1].EndTS = currSeg.EndTS
+		} else {
+			out = append(out, currSeg)
+		}
+	}
+
+	slog.Debug("compact done", slog.Int("inLen", len(segments)), slog.Int("outLen", len(out)))
+
+	return out
+}
+
+func (t Transcription) Text(w io.Writer, opts TextOptions) error {
+	segments := t.interleave()
+
+	if !opts.CompactOptions.IsEmpty() {
+		segments = compactSegments(segments, opts.CompactOptions)
+	}
+
+	for i, s := range segments {
+		s.sanitize()
+
+		nl := "\n"
+		if i == 0 {
+			nl = ""
+		}
+		_, err := fmt.Fprintf(w, "%s%v -> %v\n", nl, vttTS(s.StartTS, false), vttTS(s.EndTS, false))
+		if err != nil {
+			return fmt.Errorf("failed to write: %w", err)
+		}
+		_, err = fmt.Fprintf(w, "%s\n%s\n", s.Speaker, s.Text)
+		if err != nil {
+			return fmt.Errorf("failed to write: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/transcriber/transcribe/webvtt.go
+++ b/cmd/transcriber/transcribe/webvtt.go
@@ -1,0 +1,90 @@
+package transcribe
+
+import (
+	"fmt"
+	"html"
+	"io"
+	"math"
+	"os"
+	"strconv"
+)
+
+type WebVTTOptions struct {
+	OmitSpeaker bool
+}
+
+func (o *WebVTTOptions) IsValid() error {
+	return nil
+}
+
+func (o *WebVTTOptions) IsEmpty() bool {
+	return o == nil || *o == WebVTTOptions{}
+}
+
+func (o *WebVTTOptions) SetDefaults() {
+	o.OmitSpeaker = false
+}
+
+func (o *WebVTTOptions) FromEnv() {
+	o.OmitSpeaker, _ = strconv.ParseBool(os.Getenv("WEBVTT_OMIT_SPEAKER"))
+}
+
+func (o *WebVTTOptions) ToEnv() []string {
+	return []string{
+		fmt.Sprintf("WEBVTT_OMIT_SPEAKER=%t", o.OmitSpeaker),
+	}
+}
+
+func (o *WebVTTOptions) FromMap(m map[string]any) {
+	o.OmitSpeaker, _ = m["webvtt_omit_speaker"].(bool)
+}
+
+func (o *WebVTTOptions) ToMap() map[string]any {
+	return map[string]any{
+		"webvtt_omit_speaker": o.OmitSpeaker,
+	}
+}
+
+// vttTS converts ts milliseconds in the 00:00:00.000 format.
+func vttTS(ts int64, withMs bool) string {
+	sMs := int64(1000)
+	mMs := 60 * sMs
+	hMs := 60 * mMs
+
+	h := ts / hMs
+	m := (ts - (h * hMs)) / mMs
+
+	if withMs {
+		s := ((ts - (h * hMs)) - m*mMs) / sMs
+		ms := ((ts - (h * hMs)) - m*mMs) - s*sMs
+		return fmt.Sprintf("%02d:%02d:%02d.%03d", h, m, s, ms)
+	}
+
+	s := int64(math.Round(float64(((ts - (h * hMs)) - m*mMs)) / float64(sMs)))
+	return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
+}
+
+func (t Transcription) WebVTT(w io.Writer, opts WebVTTOptions) error {
+	_, err := fmt.Fprintf(w, "WEBVTT\n")
+	if err != nil {
+		return fmt.Errorf("failed to write: %w", err)
+	}
+	for _, s := range t.interleave() {
+		s.sanitize(html.EscapeString)
+
+		_, err = fmt.Fprintf(w, "\n%s --> %s\n", vttTS(s.StartTS, true), vttTS(s.EndTS, true))
+		if err != nil {
+			return fmt.Errorf("failed to write: %w", err)
+		}
+		tmpl := "<v %[1]s>(%[1]s) %[2]s\n"
+		if opts.OmitSpeaker {
+			tmpl = "%[2]s\n"
+		}
+		_, err = fmt.Fprintf(w, tmpl, s.Speaker, s.Text)
+		if err != nil {
+			return fmt.Errorf("failed to write: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21.4
 require (
 	github.com/mattermost/mattermost-plugin-calls/server/public v0.0.3-0.20231103204030-06bd54bcfa67
 	github.com/mattermost/mattermost/server/public v0.0.6
-	github.com/mattermost/rtcd v0.12.1-0.20231114225901-6fcc49a7d5d3
+	github.com/mattermost/rtcd v0.12.1-0.20231121174414-6a5686281335
 	github.com/pion/randutil v0.1.0
 	github.com/pion/rtp v1.8.3
 	github.com/pion/webrtc/v3 v3.2.21

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,8 @@ github.com/mattermost/mattermost-plugin-calls/server/public v0.0.3-0.20231103204
 github.com/mattermost/mattermost-plugin-calls/server/public v0.0.3-0.20231103204030-06bd54bcfa67/go.mod h1:9a5FoYxu9rPCvV4FEo0DkJSqqCZ80FCeB9Y4haBI2FQ=
 github.com/mattermost/mattermost/server/public v0.0.6 h1:FUaJ+P36E3Tt12Umdm8p1h7sZNUeObDk3p3aFTaBkCo=
 github.com/mattermost/mattermost/server/public v0.0.6/go.mod h1:Y7Ht1haGGrsuYzX73HhpSe2VnbGLuZj2/tsQslHd2/M=
-github.com/mattermost/rtcd v0.12.1-0.20231114225901-6fcc49a7d5d3 h1:aywYFLWyDekX2zC8KLXpD3zO9NZRngDENH9QIYy6YNU=
-github.com/mattermost/rtcd v0.12.1-0.20231114225901-6fcc49a7d5d3/go.mod h1:SK7+TEIpUD/rx53RUiy5KotiBzv1h08PujbK87/jw6M=
+github.com/mattermost/rtcd v0.12.1-0.20231121174414-6a5686281335 h1:PaE1X/fJftk0FgX9YjvToWnSuF4Mr77K5tuU90LRDSc=
+github.com/mattermost/rtcd v0.12.1-0.20231121174414-6a5686281335/go.mod h1:SK7+TEIpUD/rx53RUiy5KotiBzv1h08PujbK87/jw6M=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=


### PR DESCRIPTION
#### Summary

As explained in https://github.com/mattermost/mattermost-plugin-calls/pull/549#issuecomment-1820072105 we are implementing some simple heuristics to join contiguous text segments from the same speaker to avoid outputting lines with very short sentences.

Added some boilerplate to make this easily configurable from the plugin side once we deploy in case we need to tweak it further.
