### PR TITLE
[MM-55259] Return success exit code on failure to start to allow for resources cleanup

### DIFF
--- a/cmd/transcriber/call/tracks.go
+++ b/cmd/transcriber/call/tracks.go
@@ -192,7 +192,9 @@ func (t *Transcriber) handleClose() error {
 
 		samplesDur += dur
 
-		tr = append(tr, trackTr)
+		if len(trackTr.Segments) > 0 {
+			tr = append(tr, trackTr)
+		}
 	}
 
 	if len(tr) == 0 {


### PR DESCRIPTION
#### Summary

Same reasoning as in https://github.com/mattermost/calls-recorder/pull/57. Also fixed detection of empty transcriptions to avoid the upload attempt of an empty file.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55259
