### PR TITLE
[MM-56328] Handle potentially out of order packets

### DIFF
--- a/cmd/transcriber/call/tracks.go
+++ b/cmd/transcriber/call/tracks.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"time"
@@ -33,6 +34,7 @@ const (
 	trackInFrameSize          = trackAudioFrameSizeMs * trackInAudioRate / 1000  // The input frame size in samples
 	trackOutFrameSize         = trackAudioFrameSizeMs * trackOutAudioRate / 1000 // The output frame size in samples
 	audioGapThreshold         = time.Second                                      // The amount of time after which we detect a gap in the audio track.
+	rtpTSWrapAroundThreshold  = trackInAudioRate                                 // The threshold to detect if the RTP timestamp has wrapped around (one second worth of samples).
 
 	dataDir   = "/data"
 	modelsDir = "/models"
@@ -138,6 +140,24 @@ func (t *Transcriber) processLiveTrack(track trackRemote, sessionID string, user
 			continue
 		}
 
+		// We ignore out of order packets as they would cause synchronization
+		// issues. In the future we may want to reorder them but that requires us to keep
+		// buffers and complicate the whole process.
+		if pkt.Timestamp < prevRTPTimestamp {
+			slog.Debug("out of order packet",
+				slog.Int("diff", int(pkt.Timestamp)-int(prevRTPTimestamp)),
+				slog.String("trackID", ctx.trackID))
+
+			// Check that timestamp hasn't wrapped around. Fairly unlikely but it's
+			// a possibility since the starting timestamp is generated randomly so
+			// it could be close to the end of the uint32 range.
+			if hasWrappedAround := math.MaxUint32-prevRTPTimestamp < rtpTSWrapAroundThreshold; !hasWrappedAround {
+				continue
+			}
+
+			slog.Debug("ts wrap around detected", slog.String("trackID", ctx.trackID))
+		}
+
 		var gap uint64
 		if ctx.startTS == 0 {
 			ctx.startTS = time.Since(*t.startTime.Load()).Milliseconds()
@@ -152,6 +172,11 @@ func (t *Transcriber) processLiveTrack(track trackRemote, sessionID string, user
 			// TODO: check whether it may be easier to rely on sender reports to
 			// potentially achieve more accurate synchronization.
 			rtpGap := time.Duration((pkt.Timestamp-prevRTPTimestamp)/trackInAudioSamplesPerMs) * time.Millisecond
+
+			slog.Debug("receive gap detected",
+				slog.Duration("receiveGap", receiveGap), slog.Duration("rtpGap", rtpGap),
+				slog.Uint64("currTS", uint64(pkt.Timestamp)), slog.Uint64("prevTS", uint64(prevRTPTimestamp)),
+				slog.String("trackID", ctx.trackID))
 
 			if (rtpGap - receiveGap).Abs() > audioGapThreshold {
 				// If the difference between the timestamps reported in RTP packets and

--- a/cmd/transcriber/call/tracks.go
+++ b/cmd/transcriber/call/tracks.go
@@ -151,10 +151,16 @@ func (t *Transcriber) processLiveTrack(track trackRemote, sessionID string, user
 			// Check that timestamp hasn't wrapped around. Fairly unlikely but it's
 			// a possibility since the starting timestamp is generated randomly so
 			// it could be close to the end of the uint32 range.
+			// If it hasn't wrapped around then it's an out of order packet which we want
+			// to skip.
 			if hasWrappedAround := math.MaxUint32-prevRTPTimestamp < rtpTSWrapAroundThreshold; !hasWrappedAround {
 				continue
 			}
 
+			// If we detect wraparound we can then go ahead and write the packet
+			// as the increment in timestamp will handled automatically (and
+			// correctly) by the uint conversion that happens in oggWriter.WriteRTP().
+			// Example: uint32(704-4294967000) = 1000
 			slog.Debug("ts wrap around detected", slog.String("trackID", ctx.trackID))
 		}
 


### PR DESCRIPTION
#### Summary

As expected, the OGG writer didn't really handle out of order packets. Non-monotonic packets timestamps would result in a negative value [being converted to unsigned integer](https://github.com/mattermost/calls-transcriber/blob/dbf440ab27ab08d1f9aac8a499b2b9ff1d7ff6dd/cmd/transcriber/ogg/writer.go#L196) causing a huge gap (~24 hours at our default 48KHz sampling rate). For now we'll simply skip these packets as they should be rare. To improve on this we'd have to buffer them up and re-order them which can get a bit complex so deferring that work for the time being.

To be thorough I am also handling a check for potential wrap-around of the timestamp value since it's a `uint32` whose starting point is randomly generated so it can theoretically happen even in shorter calls.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-56328
