### PR TITLE
[MM-56490] Add retry logic to getFilenameForCall call

### DIFF
--- a/cmd/transcriber/call/utils.go
+++ b/cmd/transcriber/call/utils.go
@@ -63,7 +63,20 @@ func getModelsDir() string {
 }
 
 func (t *Transcriber) publishTranscription(tr transcribe.Transcription) (err error) {
-	fname, err := t.getFilenameForCall()
+	var fname string
+	for i := 0; i < maxUploadRetryAttempts; i++ {
+		if i > 0 {
+			slog.Error("getFilenameForCall failed",
+				slog.String("err", err.Error()),
+				slog.Duration("reattempt_time", uploadRetryAttemptWaitTime))
+			time.Sleep(uploadRetryAttemptWaitTime)
+		}
+
+		fname, err = t.getFilenameForCall()
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("failed to get filename for call: %w", err)
 	}


### PR DESCRIPTION
#### Summary

The API call to generate the filename wasn't part of the main retry loop so a single failure would make the whole job fail. PR wraps that into a similar retry loop.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-56490
