### PR TITLE
[MM-56951] Use track ID as audio filenames suffix

### DIFF
--- a/cmd/transcriber/call/tracks.go
+++ b/cmd/transcriber/call/tracks.go
@@ -90,7 +90,7 @@ func (t *Transcriber) processLiveTrack(track trackRemote, sessionID string, user
 		trackID:   track.ID(),
 		sessionID: sessionID,
 		user:      user,
-		filename:  filepath.Join(getDataDir(), fmt.Sprintf("%s_%s.ogg", user.Id, sessionID)),
+		filename:  filepath.Join(getDataDir(), fmt.Sprintf("%s_%s.ogg", user.Id, track.ID())),
 	}
 
 	slog.Debug("processing voice track",

--- a/cmd/transcriber/call/transcriber_test.go
+++ b/cmd/transcriber/call/transcriber_test.go
@@ -170,7 +170,7 @@ func TestProcessLiveTrack(t *testing.T) {
 			close(tr.trackCtxs)
 			require.Len(t, tr.trackCtxs, 1)
 
-			trackFile, err := os.Open(filepath.Join(getDataDir(), fmt.Sprintf("%s_%s.ogg", user.Id, sessionID)))
+			trackFile, err := os.Open(filepath.Join(getDataDir(), fmt.Sprintf("%s_%s.ogg", user.Id, track.id)))
 			defer trackFile.Close()
 			require.NoError(t, err)
 
@@ -265,7 +265,7 @@ func TestProcessLiveTrack(t *testing.T) {
 			close(tr.trackCtxs)
 			require.Len(t, tr.trackCtxs, 1)
 
-			trackFile, err := os.Open(filepath.Join(getDataDir(), fmt.Sprintf("%s_%s.ogg", user.Id, sessionID)))
+			trackFile, err := os.Open(filepath.Join(getDataDir(), fmt.Sprintf("%s_%s.ogg", user.Id, track.id)))
 			defer trackFile.Close()
 			require.NoError(t, err)
 
@@ -359,7 +359,7 @@ func TestProcessLiveTrack(t *testing.T) {
 			close(tr.trackCtxs)
 			require.Len(t, tr.trackCtxs, 1)
 
-			trackFile, err := os.Open(filepath.Join(getDataDir(), fmt.Sprintf("%s_%s.ogg", user.Id, sessionID)))
+			trackFile, err := os.Open(filepath.Join(getDataDir(), fmt.Sprintf("%s_%s.ogg", user.Id, track.id)))
 			defer trackFile.Close()
 			require.NoError(t, err)
 


### PR DESCRIPTION
#### Summary

Using the `userID_sessionID` pattern to name audio files wasn't a great choice since it's actually possible to receive multiple tracks for the same session (e.g. when users switch their audio input devices) so the result would be pretty funny as the audio would be transcribed twice (or more) and then duplicated with different timestamps in the output text and caption files based on tracks relative offsets.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-56951

