### PR TITLE
Fix validate config; report failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,7 @@ GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/service.bu
 GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/service.buildVersion=$(APP_VERSION)"
 GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/service.buildDate=$(BUILD_DATE)"
 GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/service.goVersion=$(GO_VERSION)"
+GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/cmd/transcriber/config.inTranscriber=true"
 # Architectures to build for
 GO_BUILD_PLATFORMS           ?= "linux-${ARCH}"
 GO_BUILD_PLATFORMS_ARTIFACTS = $(foreach cmd,$(addprefix go-build/,${APP_NAME}),$(addprefix $(cmd)-,$(GO_BUILD_PLATFORMS)))

--- a/cmd/transcriber/call/transcriber.go
+++ b/cmd/transcriber/call/transcriber.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -41,33 +40,45 @@ type Transcriber struct {
 	captionsPoolDoneCh  chan struct{}
 }
 
-func NewTranscriber(cfg config.CallTranscriberConfig) (*Transcriber, error) {
-	if err := cfg.IsValid(true); err != nil {
-		if apiClient, err2 := CreateAPIClient(cfg); err2 == nil {
-			t := &Transcriber{cfg: cfg, apiClient: apiClient}
-			if err3 := t.ReportJobFailure(fmt.Sprintf("failed to validate config: %s", err.Error())); err3 != nil {
-				slog.Error("failed to report job failure", slog.String("err", err3.Error()))
-			}
-		}
-		return nil, fmt.Errorf("failed to validate config: %w", err)
+func NewTranscriber(cfg config.CallTranscriberConfig) (t *Transcriber, retErr error) {
+	if err := cfg.IsValidURL(); err != nil {
+		return nil, fmt.Errorf("failed to validate URL: %w", err)
 	}
 
-	client, err := client.New(client.Config{
+	apiClient := model.NewAPIv4Client(cfg.SiteURL)
+	apiClient.SetToken(cfg.AuthToken)
+
+	t = &Transcriber{
+		cfg:       cfg,
+		apiClient: apiClient,
+	}
+
+	defer func() {
+		if retErr != nil {
+			retErrStr := fmt.Errorf("failed to create Transcriber: %w", retErr)
+			if err := t.ReportJobFailure(retErrStr.Error()); err != nil {
+				retErr = fmt.Errorf("failed to report job failure: %s, original error: %s", err.Error(), retErrStr)
+			}
+		}
+	}()
+
+	if retErr = cfg.IsValid(); retErr != nil {
+		return
+	}
+
+	var rtcdClient *client.Client
+	if rtcdClient, retErr = client.New(client.Config{
 		SiteURL:   cfg.SiteURL,
 		AuthToken: cfg.AuthToken,
 		ChannelID: cfg.CallID,
 		JobID:     cfg.TranscriptionID,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create calls client: %w", err)
+	}); retErr != nil {
+		return
 	}
 
-	// We have already validated the cfg above, so no error.
-	apiClient, _ := CreateAPIClient(cfg)
-
-	t := &Transcriber{
+	t = &Transcriber{
 		cfg:                 cfg,
-		client:              client,
+		client:              rtcdClient,
 		apiClient:           apiClient,
 		errCh:               make(chan error, 1),
 		doneCh:              make(chan struct{}),
@@ -75,30 +86,8 @@ func NewTranscriber(cfg config.CallTranscriberConfig) (*Transcriber, error) {
 		captionsPoolQueueCh: make(chan captionPackage, transcriberQueueChBuffer),
 		captionsPoolDoneCh:  make(chan struct{}),
 	}
-	return t, nil
-}
 
-func CreateAPIClient(cfg config.CallTranscriberConfig) (*model.Client4, error) {
-	if err := cfg.IsValid(true); err != nil {
-		if cfg.SiteURL == "" {
-			return nil, fmt.Errorf("SiteURL cannot be empty")
-		}
-
-		u, err := url.Parse(cfg.SiteURL)
-		if err != nil {
-			return nil, fmt.Errorf("SiteURL parsing failed: %w", err)
-		} else if u.Scheme != "http" && u.Scheme != "https" {
-			return nil, fmt.Errorf("SiteURL parsing failed: invalid scheme %q", u.Scheme)
-		} else if u.Path != "" {
-			return nil, fmt.Errorf("SiteURL parsing failed: invalid path %q", u.Path)
-		}
-
-		// We have a good enough config to make the ApiClient
-	}
-
-	apiClient := model.NewAPIv4Client(cfg.SiteURL)
-	apiClient.SetToken(cfg.AuthToken)
-	return apiClient, nil
+	return
 }
 
 func (t *Transcriber) Start(ctx context.Context) error {

--- a/cmd/transcriber/call/transcriber.go
+++ b/cmd/transcriber/call/transcriber.go
@@ -43,7 +43,7 @@ type Transcriber struct {
 
 func NewTranscriber(cfg config.CallTranscriberConfig) (*Transcriber, error) {
 	if err := cfg.IsValid(true); err != nil {
-		if apiClient, err2 := CreateApiClient(cfg); err2 == nil {
+		if apiClient, err2 := CreateAPIClient(cfg); err2 == nil {
 			t := &Transcriber{cfg: cfg, apiClient: apiClient}
 			if err3 := t.ReportJobFailure(fmt.Sprintf("failed to validate config: %s", err.Error())); err3 != nil {
 				slog.Error("failed to report job failure", slog.String("err", err3.Error()))
@@ -63,7 +63,7 @@ func NewTranscriber(cfg config.CallTranscriberConfig) (*Transcriber, error) {
 	}
 
 	// We have already validated the cfg above, so no error.
-	apiClient, _ := CreateApiClient(cfg)
+	apiClient, _ := CreateAPIClient(cfg)
 
 	t := &Transcriber{
 		cfg:                 cfg,
@@ -78,7 +78,7 @@ func NewTranscriber(cfg config.CallTranscriberConfig) (*Transcriber, error) {
 	return t, nil
 }
 
-func CreateApiClient(cfg config.CallTranscriberConfig) (*model.Client4, error) {
+func CreateAPIClient(cfg config.CallTranscriberConfig) (*model.Client4, error) {
 	if err := cfg.IsValid(true); err != nil {
 		if cfg.SiteURL == "" {
 			return nil, fmt.Errorf("SiteURL cannot be empty")

--- a/cmd/transcriber/config/config.go
+++ b/cmd/transcriber/config/config.go
@@ -112,6 +112,18 @@ func (cfg CallTranscriberConfig) IsValidURL() error {
 		return fmt.Errorf("SiteURL parsing failed: invalid path %q", u.Path)
 	}
 
+	return nil
+}
+
+func (cfg CallTranscriberConfig) IsValid() error {
+	if cfg == (CallTranscriberConfig{}) {
+		return fmt.Errorf("config cannot be empty")
+	}
+
+	if err := cfg.IsValidURL(); err != nil {
+		return err
+	}
+
 	if cfg.CallID == "" {
 		return fmt.Errorf("CallID cannot be empty")
 	} else if !idRE.MatchString(cfg.CallID) {
@@ -128,18 +140,6 @@ func (cfg CallTranscriberConfig) IsValidURL() error {
 		return fmt.Errorf("AuthToken cannot be empty")
 	} else if !idRE.MatchString(cfg.AuthToken) {
 		return fmt.Errorf("AuthToken parsing failed")
-	}
-
-	return nil
-}
-
-func (cfg CallTranscriberConfig) IsValid() error {
-	if cfg == (CallTranscriberConfig{}) {
-		return fmt.Errorf("config cannot be empty")
-	}
-
-	if err := cfg.IsValidURL(); err != nil {
-		return err
 	}
 
 	if cfg.PostID == "" {

--- a/cmd/transcriber/config/config_test.go
+++ b/cmd/transcriber/config/config_test.go
@@ -16,7 +16,7 @@ func TestConfigIsValid(t *testing.T) {
 	tcs := []struct {
 		name          string
 		cfg           CallTranscriberConfig
-		inContainer   bool
+		inTranscriber string
 		expectedError string
 	}{
 		{
@@ -39,32 +39,31 @@ func TestConfigIsValid(t *testing.T) {
 			expectedError: "CallID cannot be empty",
 		},
 		{
-			name: "missing PostID",
+			name: "missing TranscriptionID",
 			cfg: CallTranscriberConfig{
-				SiteURL:   "http://localhost:8065",
-				CallID:    "8w8jorhr7j83uqr6y1st894hqe",
-				AuthToken: "qj75unbsef83ik9p7ueypb6iyw",
+				SiteURL: "http://localhost:8065",
+				CallID:  "8w8jorhr7j83uqr6y1st894hqe",
 			},
-			expectedError: "PostID cannot be empty",
+			expectedError: "TranscriptionID cannot be empty",
 		},
 		{
 			name: "missing AuthToken",
 			cfg: CallTranscriberConfig{
-				SiteURL: "http://localhost:8065",
-				CallID:  "8w8jorhr7j83uqr6y1st894hqe",
-				PostID:  "udzdsg7dwidbzcidx5khrf8nee",
+				SiteURL:         "http://localhost:8065",
+				CallID:          "8w8jorhr7j83uqr6y1st894hqe",
+				TranscriptionID: "on5yfih5etn5m8rfdidamc1oxa",
 			},
 			expectedError: "AuthToken cannot be empty",
 		},
 		{
-			name: "missing TranscriptionID",
+			name: "missing PostID",
 			cfg: CallTranscriberConfig{
-				SiteURL:   "http://localhost:8065",
-				CallID:    "8w8jorhr7j83uqr6y1st894hqe",
-				PostID:    "udzdsg7dwidbzcidx5khrf8nee",
-				AuthToken: "qj75unbsef83ik9p7ueypb6iyw",
+				SiteURL:         "http://localhost:8065",
+				CallID:          "8w8jorhr7j83uqr6y1st894hqe",
+				TranscriptionID: "on5yfih5etn5m8rfdidamc1oxa",
+				AuthToken:       "qj75unbsef83ik9p7ueypb6iyw",
 			},
-			expectedError: "TranscriptionID cannot be empty",
+			expectedError: "PostID cannot be empty",
 		},
 		{
 			name: "invalid TranscribeAPI",
@@ -115,7 +114,7 @@ func TestConfigIsValid(t *testing.T) {
 				ModelSize:       ModelSizeMedium,
 				OutputFormat:    OutputFormatVTT,
 			},
-			inContainer:   true,
+			inTranscriber: "true",
 			expectedError: fmt.Sprintf("NumThreads should be in the range [1, %d]", runtime.NumCPU()),
 		},
 		{
@@ -130,7 +129,7 @@ func TestConfigIsValid(t *testing.T) {
 				ModelSize:       ModelSizeMedium,
 				OutputFormat:    OutputFormatVTT,
 			},
-			inContainer:   false,
+			inTranscriber: "false",
 			expectedError: "SilenceThresholdMs should be a positive number",
 		},
 		{
@@ -201,7 +200,7 @@ func TestConfigIsValid(t *testing.T) {
 					},
 				},
 			},
-			inContainer:   true,
+			inTranscriber: "true",
 			expectedError: fmt.Sprintf("LiveCaptionsNumTranscribers * LiveCaptionsNumThreadsPerTranscriber should be in the range [1, %d]", runtime.NumCPU()),
 		},
 		{
@@ -250,7 +249,7 @@ func TestConfigIsValid(t *testing.T) {
 					},
 				},
 			},
-			inContainer:   false,
+			inTranscriber: "false",
 			expectedError: "LiveCaptionsModelSize value is not valid",
 		},
 		{
@@ -312,7 +311,8 @@ func TestConfigIsValid(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.cfg.IsValid(tc.inContainer)
+			inTranscriber = tc.inTranscriber
+			err := tc.cfg.IsValid()
 			if tc.expectedError == "" {
 				require.NoError(t, err)
 			} else {
@@ -484,9 +484,11 @@ func TestCallTranscriberConfigMap(t *testing.T) {
 	cfg.OutputOptions.WebVTT.OmitSpeaker = true
 	cfg.SetDefaults()
 
+	inTranscriber = "true"
+
 	t.Run("default config", func(t *testing.T) {
 		var c CallTranscriberConfig
-		err := c.FromMap(cfg.ToMap()).IsValid(true)
+		err := c.FromMap(cfg.ToMap()).IsValid()
 		require.NoError(t, err)
 	})
 
@@ -498,7 +500,7 @@ func TestCallTranscriberConfigMap(t *testing.T) {
 		var mm map[string]any
 		err = json.Unmarshal(data, &mm)
 		require.NoError(t, err)
-		err = c.FromMap(mm).IsValid(true)
+		err = c.FromMap(mm).IsValid()
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
#### Summary
- ~~Little bit ugly nested errors there, but it works.~~ fixed
- ~~IsValid requires an `inContainer` flag, which I felt was better than moving the numCPUs check outside the confid validation; that's where it belongs, we just don't know numCPUs when we're calling `IsValid` from the elsewhere.~~ fixed
- I'm not really satisfied with how `ReportJobFailure` works, I think it's racy. It works on my local machine, but not well on calls.test: the recording is stopped, but the UI isn't updated to reflect that. Also, there's no feedback to the host about what went wrong. We can discuss in channel to figure out the best way to solve it (hopefully without time.Sleep...).

#### Ticket Link
- none
