### PR TITLE
Fix `go-build-docker` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -340,7 +340,7 @@ go-build-docker: # to build binaries under a controlled docker dedicated go cont
 	-v $(PWD):/app -w /app \
 	-e GOCACHE="/tmp" \
 	$(DOCKER_IMAGE_GO) \
-	/bin/bash ./build/build.sh ${OPUS_VERSION} ${OPUS_SHA} ${WHISPER_VERSION} ${WHISPER_SHA} ${WHISPER_MODELS} ${ONNX_VERSION} ${ARCH} || ${FAIL}
+	/bin/bash ./build/build.sh ${OPUS_VERSION} ${OPUS_SHA} ${WHISPER_VERSION} ${WHISPER_SHA} ${WHISPER_MODELS} ${ONNX_VERSION} ${ARCH} ${AZURE_SDK_VERSION} ${AZURE_SDK_SHA} || ${FAIL}
 	@$(OK) go build docker
 
 .PHONY: go-run

--- a/cmd/transcriber/apis/azure/speech_recognizer.go
+++ b/cmd/transcriber/apis/azure/speech_recognizer.go
@@ -171,6 +171,13 @@ func (s *SpeechRecognizer) TranscribeAsync(samplesCh <-chan []float32) (<-chan t
 func (s *SpeechRecognizer) Transcribe(samples []float32) ([]transcribe.Segment, string, error) {
 	// TODO: we should likely re-use the same session throughout a track transcription to optimize
 	// resources a bit.
+	//
+	// NOTE: the underlying Golang wrapper is currently a bit bugged. Re-using the client is recommended
+	// but it doesn't work properly because everything relies on a stream which can't be flushed which can
+	// lead to data loss. And if we close the stream then we need to re-initialize everything like we do.
+	//
+	// A better solution may be to extend the Transcriber interface and pass an audio reader to this method
+	// instead of the chunks we create since we are dealing with post-transcript.
 
 	inputDuration := time.Duration(float32(len(samples))/float32(audioSampleRate)) * time.Second
 


### PR DESCRIPTION
#### Summary

Forgot to update the `go-build-docker` target which is used to prepare the Github release.



