### PR TITLE
Fix stopping job

### DIFF
--- a/cmd/transcriber/call/transcriber.go
+++ b/cmd/transcriber/call/transcriber.go
@@ -143,7 +143,7 @@ func (t *Transcriber) Start(ctx context.Context) error {
 
 		if jobID == t.cfg.TranscriptionID {
 			slog.Info("received job stop event, exiting")
-			go t.done()
+			go t.client.Close()
 		}
 
 		return nil


### PR DESCRIPTION
#### Summary

The only reason this was working was that we'd still be sending the fake "call ended" event which I wanted to deprecate since we added the explicit "stop job" a long time ago. Unfortunately, doing that revealed this bug. We must close the client otherwise we'd have our live track processing goroutines indefinitely stuck waiting for more audio packets.


