### PR TITLE
[MM-63296] Bump Golang version to v1.23.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Microsoft/cognitive-services-speech-sdk-go v1.33.0
 	github.com/mattermost/mattermost-plugin-calls/server/public v0.0.0-20240308191258-3efb429339df
 	github.com/mattermost/mattermost/server/public v0.1.10
-	github.com/mattermost/rtcd v1.0.2-0.20250227184729-cfd62aba0e4a
+	github.com/mattermost/rtcd v1.0.2-0.20250310180637-d93ac54cb042
 	github.com/pion/interceptor v0.1.37
 	github.com/pion/randutil v0.1.0
 	github.com/pion/rtp v1.8.10

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/mattermost/calls-transcriber
 
-go 1.22.7
+go 1.23.6
 
 require (
 	github.com/Microsoft/cognitive-services-speech-sdk-go v1.33.0
 	github.com/mattermost/mattermost-plugin-calls/server/public v0.0.0-20240308191258-3efb429339df
 	github.com/mattermost/mattermost/server/public v0.1.10
-	github.com/mattermost/rtcd v1.0.1-0.20250226201100-dc18166f1c0f
+	github.com/mattermost/rtcd v1.0.2-0.20250227184729-cfd62aba0e4a
 	github.com/pion/interceptor v0.1.37
 	github.com/pion/randutil v0.1.0
 	github.com/pion/rtp v1.8.10

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/mattermost/mattermost-plugin-calls/server/public v0.0.0-2024030819125
 github.com/mattermost/mattermost-plugin-calls/server/public v0.0.0-20240308191258-3efb429339df/go.mod h1:9a5FoYxu9rPCvV4FEo0DkJSqqCZ80FCeB9Y4haBI2FQ=
 github.com/mattermost/mattermost/server/public v0.1.10 h1:gp3XHxqj5KDkz3venimqqNc62rqyF15uusQuBr8k7J4=
 github.com/mattermost/mattermost/server/public v0.1.10/go.mod h1:hu2sIyXm024PGIGhACqmCxvp3atrwRzXGgAzCvs6zJs=
-github.com/mattermost/rtcd v1.0.1-0.20250226201100-dc18166f1c0f h1:4F/rU0sEgm4F/z3ICHR03cOEYcvcyrxK77/r8Msc9DM=
-github.com/mattermost/rtcd v1.0.1-0.20250226201100-dc18166f1c0f/go.mod h1:lzVqrKPbsBjwc42eVHlWnXJA83khG2Ln2o7lZaMCOqs=
+github.com/mattermost/rtcd v1.0.2-0.20250227184729-cfd62aba0e4a h1:L3PGzt2rgodcSX4gr1urOQksTYxqLT1PrzyBx+1pqN4=
+github.com/mattermost/rtcd v1.0.2-0.20250227184729-cfd62aba0e4a/go.mod h1:WatPi0nzElOcKXgQTyaC/3953nn68zRDQHS6aY6Wdzw=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/mattermost/mattermost-plugin-calls/server/public v0.0.0-2024030819125
 github.com/mattermost/mattermost-plugin-calls/server/public v0.0.0-20240308191258-3efb429339df/go.mod h1:9a5FoYxu9rPCvV4FEo0DkJSqqCZ80FCeB9Y4haBI2FQ=
 github.com/mattermost/mattermost/server/public v0.1.10 h1:gp3XHxqj5KDkz3venimqqNc62rqyF15uusQuBr8k7J4=
 github.com/mattermost/mattermost/server/public v0.1.10/go.mod h1:hu2sIyXm024PGIGhACqmCxvp3atrwRzXGgAzCvs6zJs=
-github.com/mattermost/rtcd v1.0.2-0.20250227184729-cfd62aba0e4a h1:L3PGzt2rgodcSX4gr1urOQksTYxqLT1PrzyBx+1pqN4=
-github.com/mattermost/rtcd v1.0.2-0.20250227184729-cfd62aba0e4a/go.mod h1:WatPi0nzElOcKXgQTyaC/3953nn68zRDQHS6aY6Wdzw=
+github.com/mattermost/rtcd v1.0.2-0.20250310180637-d93ac54cb042 h1:b4RQpK30lUz9eWYEJL6h9UJN79E4TQwYONSUAErYLWo=
+github.com/mattermost/rtcd v1.0.2-0.20250310180637-d93ac54cb042/go.mod h1:WatPi0nzElOcKXgQTyaC/3953nn68zRDQHS6aY6Wdzw=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=


### PR DESCRIPTION
#### Summary

Bumping the Golang version used to build.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63296

