### PR TITLE
[MM-64555] Set permissions on job-scoped path

### DIFF
--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -1,4 +1,11 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -euxo pipefail
 
-chown -R calls:calls /data
+# Create scoped (by jobID) data path.
+mkdir -p /data/$TRANSCRIPTION_ID
+
+# Give permission to write transcription files.
+chown -R calls:calls /data/$TRANSCRIPTION_ID
+
+# Run job as unprivileged user.
 exec runuser -u calls "$@"

--- a/cmd/transcriber/main.go
+++ b/cmd/transcriber/main.go
@@ -42,13 +42,7 @@ func slogReplaceAttr(_ []string, a slog.Attr) slog.Attr {
 func main() {
 	trID := os.Getenv("TRANSCRIPTION_ID")
 
-	// Create scoped (by jobID) data path
 	dataPath := call.GetDataDir(trID)
-	err := os.MkdirAll(dataPath, 0700)
-	if err != nil {
-		slog.Error("failed to create data path", slog.String("err", err.Error()))
-		os.Exit(1)
-	}
 
 	logFile, err := os.Create(filepath.Join(dataPath, "transcriber.log"))
 	if err != nil {


### PR DESCRIPTION
#### Summary

When running on a shared `/data` volume, recording and transcribing jobs could race to set permissions on `/data`. This is problematic because the system user/group IDs do not match (996 vs 999). To avoid this issue altogether, we set the permissions on the job-scoped path, namely `/data/JOB_ID`.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-64555
