### PR TITLE
Fix context cancellation before response body decode in upload

### DIFF
--- a/cmd/transcriber/call/utils.go
+++ b/cmd/transcriber/call/utils.go
@@ -182,13 +182,13 @@ func (t *Transcriber) publishTranscription(tr transcribe.Transcription) (err err
 			continue
 		}
 		defer resp.Body.Close()
-		cancelCtx()
 
 		if err := json.NewDecoder(resp.Body).Decode(&us); err != nil {
 			slog.Error("failed to decode response body", slog.String("err", err.Error()))
 			lastErr = err
 			continue
 		}
+		cancelCtx()
 
 		ctx, cancelCtx = context.WithTimeout(context.Background(), httpUploadTimeout)
 		defer cancelCtx()
@@ -199,7 +199,6 @@ func (t *Transcriber) publishTranscription(tr transcribe.Transcription) (err err
 			continue
 		}
 		defer resp.Body.Close()
-		cancelCtx()
 
 		var vttFi model.FileInfo
 		if err := json.NewDecoder(resp.Body).Decode(&vttFi); err != nil {
@@ -207,6 +206,7 @@ func (t *Transcriber) publishTranscription(tr transcribe.Transcription) (err err
 			lastErr = err
 			continue
 		}
+		cancelCtx()
 
 		// text format upload
 		us = &model.UploadSession{
@@ -229,13 +229,13 @@ func (t *Transcriber) publishTranscription(tr transcribe.Transcription) (err err
 			continue
 		}
 		defer resp.Body.Close()
-		cancelCtx()
 
 		if err := json.NewDecoder(resp.Body).Decode(&us); err != nil {
 			slog.Error("failed to decode response body", slog.String("err", err.Error()))
 			lastErr = err
 			continue
 		}
+		cancelCtx()
 
 		ctx, cancelCtx = context.WithTimeout(context.Background(), httpUploadTimeout)
 		defer cancelCtx()
@@ -246,7 +246,6 @@ func (t *Transcriber) publishTranscription(tr transcribe.Transcription) (err err
 			continue
 		}
 		defer resp.Body.Close()
-		cancelCtx()
 
 		var textFi model.FileInfo
 		if err := json.NewDecoder(resp.Body).Decode(&textFi); err != nil {
@@ -254,6 +253,7 @@ func (t *Transcriber) publishTranscription(tr transcribe.Transcription) (err err
 			lastErr = err
 			continue
 		}
+		cancelCtx()
 
 		// attaching post VTT and text formatted files.
 		payload, err = json.Marshal(public.TranscribingJobInfo{


### PR DESCRIPTION
#### Summary
In upload code, the context is canceled before the response body is parsed. So this code only works when the message has already been read and buffered. If not the parse fails with "context canceled" error. The solution is to close the context only after the response body is parsed.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68111
