### PR TITLE
Migrate to golangci-lint v2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,31 +1,53 @@
+version: "2"
 run:
-  timeout: 5m
   modules-download-mode: readonly
-
-linters-settings:
-  gofmt:
-    simplify: true
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-      - shadow
-
 linters:
-  disable-all: true
+  default: none
   enable:
-    - gofmt         # Checks whether code was gofmt-ed
-    - revive        # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint
-    - gosimple      # Linter for Go source code that specializes in simplifying a code
-    - govet         # Examines Go source code and reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
-    - ineffassign   # Detects when assignments to existing variables are not used
-    - unconvert     # Removes unnecessary type conversions
-    - unused        # Checks Go code for unused constants, variables, functions and types
-    - copyloopvar   # Checks for pointers to enclosing loop variables
-    - errcheck      # Detects unchecked errors.
-
-issues:
-  exclude-rules:
-    - linters:
-      - unused
-      text: "getConfiguration"
+    - copyloopvar
+    - errcheck
+    - govet
+    - ineffassign
+    - revive
+    - staticcheck
+    - unconvert
+    - unused
+  settings:
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+    staticcheck:
+      # v1 enabled only the gosimple (S1xxx) checks via the `gosimple` linter,
+      # which v2 folds into `staticcheck`. Restrict to S1* to preserve the
+      # previous behavior; adopting the SA/ST/QF checks is a separate change.
+      checks:
+        - S1*
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - unused
+        text: getConfiguration
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  settings:
+    gofmt:
+      simplify: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ DOCKER_USER             ?= user
 DOCKER_PASSWORD         ?= password
 ## Docker Images
 DOCKER_IMAGE_GO         += "golang:${GO_VERSION}"
-DOCKER_IMAGE_GOLINT     += "golangci/golangci-lint:v1.64.5@sha256:9faef4dda4304c4790a14c5b8c8cd8c2715a8cb754e13f61d8ceaa358f5a454a"
+DOCKER_IMAGE_GOLINT     += "golangci/golangci-lint:v2.6.0@sha256:cc8c1277eefdb5f88ba1381ee30a8bdf709e3615db9c843c9fcc04d9ac1d27a8"
 DOCKER_IMAGE_DOCKERLINT += "hadolint/hadolint:v2.12.0@sha256:9259e253a4e299b50c92006149dd3a171c7ea3c5bd36f060022b5d2c1ff0fbbe"
 DOCKER_IMAGE_COSIGN     += "bitnami/cosign:1.8.0@sha256:8c2c61c546258fffff18b47bb82a65af6142007306b737129a7bd5429d53629a"
 DOCKER_IMAGE_GH_CLI     += "ghcr.io/supportpal/github-gh-cli:2.31.0@sha256:71371e36e62bd24ddd42d9e4c720a7e9954cb599475e24d1407af7190e2a5685"


### PR DESCRIPTION
## Summary

Bumps the lint tooling to **golangci-lint v2.6.0** (built with Go 1.25) and migrates `.golangci.yml` to the v2 schema.

golangci-lint v1 (the previous pin, `v1.64.5`, built with Go 1.24) refuses to lint a module targeting Go 1.25:
> `can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)`

The LiveKit transcriber work (MM-69374) pulls a dependency chain that requires Go 1.25, so the linter must be able to lint Go 1.25 modules. Splitting this out as a standalone tooling PR follows the repo convention (Go/lint/dependency bumps land on their own).

## Changes

- `Makefile`: `DOCKER_IMAGE_GOLINT` → `golangci/golangci-lint:v2.6.0` (pinned by digest).
- `.golangci.yml`: migrated to v2 schema (via `golangci-lint migrate`).
  - `gofmt` moves to the new `formatters` section.
  - `gosimple` is folded into `staticcheck` in v2; `staticcheck` is restricted to the `S1*` (gosimple) checks to **preserve the previous coverage exactly** — no behavior change, no new findings.

## Notes

- This is a faithful, behavior-preserving migration. Adopting the additional `staticcheck` checks now bundled under v2 (SA/ST/QF) is intentionally left as a separate change — running them surfaced a handful of pre-existing findings that should be addressed deliberately.
- Verified: `make go-lint` passes clean (0 issues) against this branch.